### PR TITLE
function needs to be called for url's actual value

### DIFF
--- a/bin/mcdetect.js
+++ b/bin/mcdetect.js
@@ -37,7 +37,7 @@ var dirtyTargets = 0;
   const failedReqs = {};
 
   page.on('requestfailed', r => {
-    failedReqs[r._requestId] = r.url;
+    failedReqs[r._requestId] = r.url();
   });
 
   page._client.on('Network.loadingFailed', r => {


### PR DESCRIPTION
Hi @agis 

I had to make this change otherwise urls were shown as:
```
	Blockable: url() {
    return this._url;
  }
	Blockable: url() {
    return this._url;
  }
	Blockable: url() {
    return this._url;
  }
```

Running node `v9.4.0` and npm `5.6.0`

Steps to reproduce:
- Clone repo
- `npm install`
- `./bin/mcdetect.js https://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/active-mixed-content.html`